### PR TITLE
FIX Don't require cms module

### DIFF
--- a/tests/Listener/CMSMain/CMSMainFake.php
+++ b/tests/Listener/CMSMain/CMSMainFake.php
@@ -6,6 +6,10 @@ namespace SilverStripe\CMSEvents\Tests\Listener\CMSMain;
 
 use SilverStripe\CMS\Controllers\CMSMain;
 
+if (!class_exists(CMSMain::class)) {
+    return;
+}
+
 class CMSMainFake extends CMSMain
 {
     private static $allowed_actions = [


### PR DESCRIPTION
Same check is already implemented in Listener\CMSMain,
but not in the test fake.