### PR TITLE
FIX: Bump min testing version to 4.5 to match composer requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+vendor
+resources

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+services:
+  - mysql
+
 env:
   global:
     - TRAVIS_NODE_VERSION="10"
@@ -7,7 +10,7 @@ env:
 matrix:
   include:
     - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.5.1 PHPUNIT_TEST=1
     - php: 7.3
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 
@@ -16,7 +19,7 @@ before_script:
   - phpenv config-rm xdebug.ini
 
   - composer validate
-  - composer require --no-update silverstripe/recipe-testing:^1 silverstripe/recipe-cms:"$RECIPE_VERSION"
+  - composer require --no-update silverstripe/recipe-cms:"$RECIPE_VERSION"
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 
   - composer validate
   - composer require --no-update silverstripe/recipe-cms:"$RECIPE_VERSION"
-  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+  - composer install --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi

--- a/tests/Fake/DataObjectFake.php
+++ b/tests/Fake/DataObjectFake.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SilverStripe\CMSEvents\Tests\Fake;
+
+use SilverStripe\Assets\File;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ManyManyList;
+use SilverStripe\Security\Member;
+
+/**
+ * @property string $MyField
+ * @property int $MyInt
+ * @method Member Author()
+ * @method ManyManyList Files()
+ */
+class DataObjectFake extends DataObject implements TestOnly
+{
+    private static $table_name = 'CMSEvents_DataObjectFake';
+
+    private static $db = [
+        'MyField' => 'Varchar',
+        'MyInt' => 'Int'
+    ];
+
+    private static $has_one = [
+        'Author' => Member::class
+    ];
+
+    private static $many_many = [
+        'Files' => File::class
+    ];
+
+    private static $searchable_fields = [
+        'MyField',
+        'MyInt',
+    ];
+
+    private static $default_sort = '"GraphQL_DataObjectFake"."MyField" ASC';
+
+    public $customSetterFieldResult;
+
+    public $customSetterMethodResult;
+
+    public function getCustomGetter()
+    {
+        return 'customGetterValue';
+    }
+
+    public function customMethod()
+    {
+        return 'customMethodValue';
+    }
+
+    public function setCustomSetterField($val)
+    {
+        $this->customSetterFieldResult = $val;
+    }
+
+    public function customSetterMethod($val)
+    {
+        $this->customSetterMethodResult = $val;
+    }
+
+    public function canCreate($member = null, $context = [])
+    {
+        return true;
+    }
+
+    public function canEdit($member = null)
+    {
+        return true;
+    }
+
+    public function canView($member = null)
+    {
+        return true;
+    }
+
+    public function canDelete($member = null)
+    {
+        return true;
+    }
+}

--- a/tests/Listener/CMSMain/ListenerTest.php
+++ b/tests/Listener/CMSMain/ListenerTest.php
@@ -13,6 +13,9 @@ use SilverStripe\EventDispatcher\Event\EventContextInterface;
 
 class ListenerTest extends SapphireTest
 {
+
+    protected $usesDatabase = true;
+
     public function testListener()
     {
         $dispatcherMock = $this->getMockBuilder(Dispatcher::class)

--- a/tests/Listener/GraphQL/Middleware/ListenerTest.php
+++ b/tests/Listener/GraphQL/Middleware/ListenerTest.php
@@ -8,7 +8,7 @@ use SilverStripe\EventDispatcher\Dispatch\Dispatcher;
 use SilverStripe\EventDispatcher\Dispatch\EventDispatcherInterface;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
 use SilverStripe\GraphQL\Manager;
-use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
+use SilverStripe\CMSEvents\Tests\Fake\DataObjectFake;
 
 class ListenerTest extends SapphireTest
 {

--- a/tests/Listener/GraphQL/Mutation/ListenerTest.php
+++ b/tests/Listener/GraphQL/Mutation/ListenerTest.php
@@ -12,7 +12,7 @@ use SilverStripe\CMSEvents\Listener\GraphQL\Mutation\Listener;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Create;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Delete;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Update;
-use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
+use SilverStripe\CMSEvents\Tests\Fake\DataObjectFake;
 use SilverStripe\Security\Member;
 
 class ListenerTest extends SapphireTest


### PR DESCRIPTION
This is necessary due to the updated GraphQL requirement