### PR TITLE
Require event-dispatcher 0.1 rather than dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/framework": "^4.5.1",
-        "silverstripe/event-dispatcher": "dev-master"
+        "silverstripe/event-dispatcher": "^0.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
A dev-master requirement currently conflicts with silverstripe/graphql:4.x-dev requirements,
which means you can't install it alongside silverstripe/versioned-snapshots.
This is a safe change because this dev-master dependency pre-dates the 0.1.0 and 0.1.1 tags